### PR TITLE
fix: .bashrc で Homebrew PATH 追加・puffer.fish を abbr に置換

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ VS Code のユーザー設定に登録するだけで、コンテナ起動時に
 | jorgebucaran/autopair.fish | 括弧・クォートの自動補完 |
 | franciscolourenco/done | 長時間コマンド完了時に通知 |
 | decors/fish-colored-man | man ページに色付け |
-| jorgebucaran/puffer.fish | `...` を `../..` に展開等 |
 | gazorby/fish-abbreviation-tips | 省略形があるコマンドにヒント表示 |
 | meaningful-ooo/sponge | 失敗したコマンドを履歴から除外 |
 | oh-my-fish/plugin-foreign-env | bash/zsh の env ファイル読み込み |

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -1,0 +1,14 @@
+# Homebrew PATH (Linux / WSL)
+if [ -d /home/linuxbrew/.linuxbrew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"
+fi
+
+# インタラクティブな bash セッションで fish が使えるのにデフォルトシェルになっていない場合は切り替える
+# Dev Container など chsh が使えない環境向け
+case $- in
+  *i*)
+    if [ -z "$FISH_VERSION" ] && command -v fish >/dev/null 2>&1 && [ "$SHELL" != "$(command -v fish 2>/dev/null)" ]; then
+      exec fish
+    fi
+    ;;
+esac

--- a/dot_config/fish/conf.d/20_abbr.fish
+++ b/dot_config/fish/conf.d/20_abbr.fish
@@ -30,5 +30,7 @@ abbr -a czu  'chezmoi update'
 abbr -a czcd 'chezmoi cd'
 
 # ── ナビゲーション ────────────────────────────
-abbr -a ..   'cd ..'
-abbr -a du   'dust'
+abbr -a ..    'cd ..'
+abbr -a ...   'cd ../..'
+abbr -a ....  'cd ../../..'
+abbr -a du    'dust'

--- a/dot_config/fish/fish_plugins
+++ b/dot_config/fish/fish_plugins
@@ -3,7 +3,6 @@ PatrickF1/fzf.fish
 jorgebucaran/autopair.fish
 franciscolourenco/done
 decors/fish-colored-man
-jorgebucaran/puffer.fish
 gazorby/fish-abbreviation-tips
 meaningful-ooo/sponge
 oh-my-fish/plugin-foreign-env


### PR DESCRIPTION
## Summary

- `dot_bashrc` を追加: Homebrew を PATH に追加し、`chsh` 不可環境（Dev Container 等）でインタラクティブ bash から fish へ自動切り替え
- `fish_plugins` から `jorgebucaran/puffer.fish` を削除（取得不可のため）
- `20_abbr.fish` に `...` / `....` の abbreviation を追加して代替

## Test plan

- [ ] CI pass を確認
- [ ] Dev Container で `chezmoi init --apply` 後に bash が自動で fish に切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)