### PR TITLE
fix: starship jj_status の不正キー削除・fisher 検出修正

### DIFF
--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -66,7 +66,16 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
             set prev_section $section
         end
 
-        if command -q $cmd
+        # fisher は fish 関数なので command -q では検出できない
+        if test "$cmd" = fisher
+            if functions -q fisher
+                echo "✅ $name (fish function)"
+                set ok (math $ok + 1)
+            else
+                echo "❌ $name (not installed)"
+                set ng (math $ng + 1)
+            end
+        else if command -q $cmd
             echo "✅ $name ("(command -v $cmd)")"
             set ok (math $ok + 1)
         else

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -25,10 +25,8 @@ style  = "bold purple"
 style = "bold red"
 
 [jj_status]
-symbol            = "󰊢 "
-style             = "bold yellow"
-conflicted        = "⚡"
-diverged          = "⇕"
+symbol = "󰊢 "
+style  = "bold yellow"
 
 [character]
 success_symbol = "[❯](bold green)"


### PR DESCRIPTION
## Summary

- `starship.toml`: `jj_status` の `conflicted` / `diverged` は有効なキーではなかったため削除（起動時 WARN の原因）
- `dotfiles-doctor.fish`: fisher は fish 関数であり `command -q` では検出できないため `functions -q fisher` に変更

## Test plan

- [ ] CI pass を確認
- [ ] fish 起動時に starship の WARN が出ないことを確認
- [ ] `dotfiles-doctor` で fisher が ✅ になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)