### PR TITLE
fix: fisher 検出を type -q に変更・ターミナル再起動後の PATH 問題を修正

### DIFF
--- a/dot_bash_profile
+++ b/dot_bash_profile
@@ -1,0 +1,4 @@
+# .bashrc を読み込む（インタラクティブログインシェル向け）
+if [ -f ~/.bashrc ]; then
+  source ~/.bashrc
+fi

--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -66,10 +66,10 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
             set prev_section $section
         end
 
-        # fisher は fish 関数なので command -q では検出できない
+        # fisher は fish 関数なので command -q では検出できない。type -q はオートロードパスも検索する
         if test "$cmd" = fisher
-            if functions -q fisher
-                echo "✅ $name (fish function)"
+            if type -q fisher
+                echo "✅ $name (~/.config/fish/functions/fisher.fish)"
                 set ok (math $ok + 1)
             else
                 echo "❌ $name (not installed)"


### PR DESCRIPTION
## Summary

- `dotfiles-doctor`: `functions -q` → `type -q` に変更（未ロード関数も検出可能）
- `dot_bash_profile` を追加: ログインシェルが `.bashrc` をスキップする問題を解消し、ターミナル再起動後も Homebrew PATH と fish 自動起動が有効になる

## Test plan

- [ ] CI pass を確認
- [ ] ターミナル再起動後に fish が自動起動することを確認
- [ ] `dotfiles-doctor` で fisher が ✅ になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)