### PR TITLE
fix: starship jj_status の symbol を format 文字列に移動・fisher 検出修正

### DIFF
--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -66,10 +66,10 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
             set prev_section $section
         end
 
-        # fisher は fish 関数なので command -q では検出できない
+        # fisher は fish 関数なので command -q では検出できない。type -q はオートロードパスも検索する
         if test "$cmd" = fisher
-            if functions -q fisher
-                echo "✅ $name (fish function)"
+            if type -q fisher
+                echo "✅ $name (~/.config/fish/functions/fisher.fish)"
                 set ok (math $ok + 1)
             else
                 echo "❌ $name (not installed)"

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -25,7 +25,7 @@ style  = "bold purple"
 style = "bold red"
 
 [jj_status]
-symbol = "󰊢 "
+format = "[󰊢  $all_status$ahead_count$behind_count]($style) "
 style  = "bold yellow"
 
 [character]


### PR DESCRIPTION
## Summary

- `starship.toml`: `jj_status` の `symbol` キーが starship 1.25.1 では無効なため、アイコンを `format` 文字列に直接埋め込む形に変更（WARN 根本対処）
- `dotfiles-doctor.fish`: rebase 時に失われた `type -q fisher` の修正を再適用

## Test plan

- [ ] CI pass を確認
- [ ] fish 起動時に starship の WARN が出ないことを確認
- [ ] `dotfiles-doctor` で fisher が ✅ になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)