### PR TITLE
fix: starship jj_status の style キーを format に移動（WARN 完全解消）

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -25,8 +25,7 @@ style  = "bold purple"
 style = "bold red"
 
 [jj_status]
-format = "[󰊢  $all_status$ahead_count$behind_count]($style) "
-style  = "bold yellow"
+format = "[󰊢  $all_status$ahead_count$behind_count](bold yellow) "
 
 [character]
 success_symbol = "[❯](bold green)"


### PR DESCRIPTION
## Summary

starship 1.25.1 の `jj_status` では `style` キーも無効なため、スタイルを `format` 文字列に直接埋め込む形に変更し Unknown key WARN を完全に解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)