### PR TITLE
fix: [jj_status] セクションを削除（WARN 根本解消）

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -24,9 +24,6 @@ style  = "bold purple"
 [git_status]
 style = "bold red"
 
-[jj_status]
-format = "[󰊢  $all_status$ahead_count$behind_count](bold yellow) "
-
 [character]
 success_symbol = "[❯](bold green)"
 error_symbol   = "[❯](bold red)"


### PR DESCRIPTION
## Summary

starship 1.25.1 では `jj_status` モジュールの設定キーがすべて Unknown key となるため、`[jj_status]` セクション自体を削除してデフォルト表示に委ねる。  
`$jj_status` はプロンプト `format` に残るため、jj の状態表示は継続される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)