### PR TITLE
fix: show informational message for DevContainer default shell

### DIFF
--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -103,6 +103,8 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
     set -l fish_path (command -v fish 2>/dev/null)
     if test "$SHELL" = "$fish_path"
         echo "✅ default shell is fish ($fish_path)"
+    else if test -n "$REMOTE_CONTAINERS"; or test -n "$CODESPACES"
+        echo "ℹ️  default shell: bash → fish (auto-exec via .bashrc, expected in DevContainer)"
     else
         echo "⚠️  default shell: $SHELL (expected: $fish_path)"
     end


### PR DESCRIPTION
## Summary

- DevContainer では `chsh` が使えないため `$SHELL` が bash のままになる
- 従来は `⚠️` (警告) が表示されていたが、これは正常な状態なので紛らわしかった
- `$REMOTE_CONTAINERS` または `$CODESPACES` が設定されている場合は `ℹ️` (情報) として表示するよう変更

## Before / After

**Before:**
```
⚠️  default shell: /bin/bash (expected: /home/linuxbrew/.linuxbrew/bin/fish)
```

**After (DevContainer内):**
```
ℹ️  default shell: bash → fish (auto-exec via .bashrc, expected in DevContainer)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)