### PR TITLE
chore: remove stale .devcontainer ref and unused --promptString in CI

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,7 +5,6 @@ README.md
 .git
 .gitignore
 .github
-.devcontainer
 
 # ── スクリプトが参照する管理ファイル ─────────
 # これらは source 内では使うが、ホームディレクトリには置きたくない

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,9 @@ jobs:
         run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
 
       - name: Render .chezmoi.toml.tmpl
-        # --promptString PROMPT=VALUE の PROMPT は promptStringOnce の第3引数にマッチ
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          chezmoi execute-template \
-            --init \
-            --promptString "Your full name=CI Test" \
-            --promptString "Your email address=ci@test.local" \
+          chezmoi execute-template --init \
             < .chezmoi.toml.tmpl > /tmp/rendered.toml
           echo "── Rendered .chezmoi.toml ──"
           cat /tmp/rendered.toml


### PR DESCRIPTION
## Summary

- `.chezmoiignore` から削除済みの `.devcontainer` エントリを除去
- `promptStringOnce` 削除に伴い CI の `--promptString` フラグ（name/email）も除去

どちらも動作には影響しないが、stale なコードを整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)