### PR TITLE
fix: add -b ~/.local/bin to chezmoi install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### Mac / WSL
 
 ```bash
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply <YOUR_USERNAME>
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin init --apply <YOUR_USERNAME>
 ```
 
 実行後、Git / jj のユーザー情報を手動で設定してください。


### PR DESCRIPTION
## Summary

`-b` を指定しないと chezmoi が `~/bin/` にインストールされ、
`~/.local/bin/chezmoi` を期待すると "no such file or directory" になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)