### PR TITLE
fix: correct WezTerm alt key config field names

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -57,8 +57,8 @@ elseif file_exists("/usr/local/bin/fish") then
 end
 
 -- Mac: Option キーを Meta として使用
-config.send_composed_key_when_left_alt_down  = false
-config.send_composed_key_when_right_alt_down = false
+config.send_composed_key_when_left_alt_is_pressed  = false
+config.send_composed_key_when_right_alt_is_pressed = false
 {{- end }}
 
 -- ── キーバインド ──────────────────────────────


### PR DESCRIPTION
## Summary

`send_composed_key_when_left_alt_down` / `send_composed_key_when_right_alt_down` は
存在しないフィールド名で WezTerm 起動時にエラーになっていた。

正しくは `send_composed_key_when_left_alt_is_pressed` /
`send_composed_key_when_right_alt_is_pressed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)