### PR TITLE
fix: set TERM=xterm-256color in WezTerm to fix lazygit patch pane

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -37,6 +37,9 @@ config.scrollback_lines = 10000
 -- ── ベル無効 ──────────────────────────────────
 config.audible_bell = "Disabled"
 
+-- ── 互換性 ────────────────────────────────────
+config.term = "xterm-256color"
+
 -- ── OS 別設定 ─────────────────────────────────
 {{ if .is_wsl -}}
 -- WSL: デフォルトシェルを WSL の fish に設定


### PR DESCRIPTION
## Summary

WezTerm のデフォルト `TERM=wezterm` を認識できないアプリ（lazygit のパッチペインなど）が
"terminal is not fully functional" を表示していた。

`config.term = "xterm-256color"` を追加して互換性を確保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)