### PR TITLE
fix: remove deprecated git.paging from lazygit config

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -10,10 +10,5 @@ gui:
   showIcons: true
   mouseEvents: true
 
-git:
-  paging:
-    colorArg: always
-    pager: "bat --style=plain --color=always"
-
 os:
   editPreset: helix


### PR DESCRIPTION
## Summary

lazygit v0.61 で `git.paging` が廃止。起動のたびに migration warning が出ていた。

`~/.gitconfig` に delta が設定済みのため lazygit 側の pager 設定は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)