### PR TITLE
fix: Brewfileからchezmoiを削除して二重インストールを防ぐ

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,9 +2,6 @@
 brew "fish"
 brew "starship"
 
-# ── dotfiles manager ──────────────────────────
-brew "chezmoi"
-
 # ── Git / VCS ─────────────────────────────────
 brew "git"
 brew "git-delta"  # 高機能 diff viewer


### PR DESCRIPTION
get.chezmoi.io で既にインストールされた chezmoi を brew bundle が 再度インストールしてしまう問題を修正。
chezmoi のアップデートは `chezmoi upgrade` で対応できるため Homebrew 管理は不要。