### PR TITLE
fix: remove jj_status from starship config (unsupported module)

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -9,7 +9,6 @@ $directory\
 [](bg:yellow fg:peach)\
 $git_branch\
 $git_status\
-$jj_status\
 [](fg:yellow bg:green)\
 $c\
 $rust\
@@ -83,10 +82,6 @@ style = "bg:yellow"
 format = '[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
 
 [git_status]
-style = "bg:yellow"
-format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
-
-[jj_status]
 style = "bg:yellow"
 format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
 


### PR DESCRIPTION
starship は jj_status モジュールを持たないため、[jj_status] セクションと $jj_status をフォーマットから削除。警告の原因だった。