### PR TITLE
fix: functions -q を type -q に変更（fish バージョン互換性）

### DIFF
--- a/dot_config/fish/conf.d/40_fzf.fish
+++ b/dot_config/fish/conf.d/40_fzf.fish
@@ -15,6 +15,6 @@ set -gx FZF_DEFAULT_OPTS "\
   --color=prompt:#cba6f7,hl+:#f38ba8"
 
 # Ctrl+R: 履歴検索 / Ctrl+T: ファイル検索 / Alt+C: ディレクトリ移動
-if functions -q fzf_configure_bindings 2>/dev/null
+if type -q fzf_configure_bindings
     fzf_configure_bindings
 end


### PR DESCRIPTION
functions -q は古い fish で未対応のためコンディションが常に偽になっていた。
type -q に置き換えて fzf_configure_bindings が正しく呼ばれるよう修正。