### PR TITLE
fix: fzf ディレクトリ検索を Ctrl+T に明示的に割り当て

### DIFF
--- a/dot_config/fish/conf.d/40_fzf.fish
+++ b/dot_config/fish/conf.d/40_fzf.fish
@@ -14,7 +14,8 @@ set -gx FZF_DEFAULT_OPTS "\
   --color=marker:#f5e0dc,fg+:#cdd6f4 \
   --color=prompt:#cba6f7,hl+:#f38ba8"
 
-# Ctrl+R: 履歴検索 / Ctrl+T: ファイル検索 / Alt+C: ディレクトリ移動
+# fzf.fish キーバインド（デフォルトから Ctrl+T をディレクトリ検索に割り当て）
+# Ctrl+T: ディレクトリ検索, Ctrl+R: 履歴, Ctrl+Alt+S: git status
 if type -q fzf_configure_bindings
-    fzf_configure_bindings
+    fzf_configure_bindings --directory=ctrl-t
 end


### PR DESCRIPTION
fzf.fish の新しいバージョンではデフォルトのディレクトリ検索が
Ctrl+T から Ctrl+Alt+F に変更されたため、
fzf_configure_bindings --directory=ctrl-t で明示的に指定するよう修正。