### PR TITLE
fix: fzf Ctrl+T バインドを config.fish に移動

### DIFF
--- a/dot_config/fish/conf.d/40_fzf.fish
+++ b/dot_config/fish/conf.d/40_fzf.fish
@@ -14,8 +14,4 @@ set -gx FZF_DEFAULT_OPTS "\
   --color=marker:#f5e0dc,fg+:#cdd6f4 \
   --color=prompt:#cba6f7,hl+:#f38ba8"
 
-# fzf.fish キーバインド（デフォルトから Ctrl+T をディレクトリ検索に割り当て）
-# Ctrl+T: ディレクトリ検索, Ctrl+R: 履歴, Ctrl+Alt+S: git status
-if type -q fzf_configure_bindings
-    fzf_configure_bindings --directory=ctrl-t
-end
+# キーバインドは config.fish で設定（conf.d の読み込み順の影響を避けるため）

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -20,3 +20,10 @@ alias pbpaste 'powershell.exe -command Get-Clipboard'
 {{ if .is_mac -}}
 # Mac 固有の設定があればここに追加
 {{- end }}
+
+# ── fzf キーバインド（conf.d より後に実行して上書きを防ぐ）─
+# fzf.fish プラグインの conf.d が Ctrl+T をデフォルトに戻すため、
+# config.fish の末尾で明示的に再設定する
+if type -q fzf_configure_bindings
+    fzf_configure_bindings --directory=ctrl-t
+end


### PR DESCRIPTION
conf.d の読み込みはアルファベット順のため 40_fzf.fish → fzf.fish の順で実行され、 fzf プラグインの conf.d が Ctrl+T をデフォルト(ctrl-alt-f)に戻してしまう問題を修正。 config.fish は conf.d より後に読まれるため、ここで fzf_configure_bindings を 呼ぶことで確実に Ctrl+T が有効になる。