### PR TITLE
feat: install.sh の結合テストを CI に追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,64 @@ jobs:
           # fish 設定は ShellCheck の対象外、.tmpl は構文が違うので別途検証済み
           ignore_paths: dot_config
           ignore_names: "*.tmpl"
+
+  integration-test:
+    name: Integration test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link checkout to ~/dotfiles
+        run: ln -s "$GITHUB_WORKSPACE" ~/dotfiles
+
+      - name: Run install.sh
+        run: bash ~/dotfiles/install.sh
+
+      - name: Set PATH for verification
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
+      - name: chezmoi が ~/.local/bin 経由で使えるか
+        run: |
+          test -f "$HOME/.local/bin/chezmoi" || command -v chezmoi
+          chezmoi --version
+          echo "✅ chezmoi accessible"
+
+      - name: fish がインストールされているか
+        run: |
+          fish --version
+          echo "✅ fish installed"
+
+      - name: starship.toml が生成されているか
+        run: |
+          test -f "$HOME/.config/starship.toml" \
+            && echo "✅ starship.toml exists" \
+            || (echo "❌ starship.toml missing"; exit 1)
+
+      - name: fish の PATH に ~/.local/bin が含まれているか
+        run: |
+          fish -c "
+            contains -- \$HOME/.local/bin \$PATH
+            or begin
+              echo '❌ ~/.local/bin not in fish PATH'
+              echo 'PATH: '\$PATH
+              exit 1
+            end
+            echo '✅ ~/.local/bin in fish PATH'
+          "
+
+      - name: mise が chezmoi ソースを trust しているか
+        run: |
+          cd ~/dotfiles/dot_config
+          if mise config ls 2>&1 | grep -q "not trusted"; then
+            echo "❌ mise still shows 'not trusted' in dotfiles source dir"
+            mise config ls 2>&1
+            exit 1
+          fi
+          echo "✅ mise trust OK"

--- a/run_once_after_35-setup-starship.sh
+++ b/run_once_after_35-setup-starship.sh
@@ -2,6 +2,17 @@
 # preset: gruvbox-rainbow
 # このコメントのプリセット名を変えると chezmoi が再実行する
 
+# chezmoi 実行時は brew が PATH に入っていないため明示的にロード
+if ! command -v starship &>/dev/null; then
+  if [ -d /home/linuxbrew/.linuxbrew ]; then
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+  elif [ -d /opt/homebrew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -d /usr/local/Homebrew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
 if ! command -v starship &>/dev/null; then
   echo "starship not installed yet, skipping."
   exit 0

--- a/run_onchange_after_45-mise-trust-source.sh.tmpl
+++ b/run_onchange_after_45-mise-trust-source.sh.tmpl
@@ -4,6 +4,17 @@
 # dot_config/ で作業すると mise がこのファイルをプロジェクト設定として検出し
 # "not trusted" エラーを出すため、apply のたびに自動で trust する。
 
+# chezmoi 実行時は brew が PATH に入っていないため明示的にロード
+if ! command -v mise &>/dev/null; then
+  if [ -d /home/linuxbrew/.linuxbrew ]; then
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+  elif [ -d /opt/homebrew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -d /usr/local/Homebrew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
 if ! command -v mise &>/dev/null; then
   echo "mise not found, skipping."
   exit 0


### PR DESCRIPTION
テンプレート検証だけだった CI に実際の install.sh 実行テストを追加。
ubuntu / macOS の両環境で以下を検証する：
- install.sh が完走するか
- chezmoi が ~/.local/bin 経由で使えるか
- fish がインストールされているか
- starship.toml が生成されているか
- fish の PATH に ~/.local/bin が含まれているか
- dot_config/ で mise の "not trusted" エラーが出ないか