### PR TITLE
fix: WezTerm フォント名を Moralerspace Neon NF → Moralerspace Neon に修正

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -5,7 +5,7 @@ local config  = wezterm.config_builder()
 -- HackGenNerd: Japanese support + Nerd Font icons (Mac は cask で自動インストール)
 -- WSLの場合は Windows 側にフォントを手動インストールが必要
 config.font = wezterm.font_with_fallback({
-  "Moralerspace Neon NF",
+  "Moralerspace Neon",
   "HackGen35 Console NF",
   "HackGenNerd Console",
   "JetBrainsMono Nerd Font",


### PR DESCRIPTION
## Summary

- v2.0.0 から Nerd Font グリフが `font-moralerspace` 本体に統合され、フォントファミリー名の `NF` サフィックスが廃止された
- `"Moralerspace Neon NF"` が認識されず fallback フォントが使われていたため修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)