### PR TITLE
fix: READMEの2点を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ czcd  # chezmoi cd     （ソースディレクトリへ移動）
 
 chezmoi テンプレートで環境を判定し、WSL・macOS・Linux で異なる設定を自動適用します。
 
-- **WSL**: WezTerm の設定ファイルを Windows 側へ自動シンボリックリンク
+- **WSL**: WezTerm の設定ファイルを Windows 側へ自動コピー（WSL からのシンボリックリンクは Windows 側アプリに認識されないため）
 - **macOS**: `Brewfile.mac` の cask（フォント・GUI アプリ）を追加インストール
 
 ### 言語バージョンを mise で一元管理
@@ -205,8 +205,8 @@ dotfiles/
 ├── run_onchange_before_20-install-packages.sh.tmpl # Brewfile 変更時に再実行
 ├── run_once_after_30-setup-fish.sh.tmpl            # fish を default shell に
 ├── run_onchange_after_40-setup-wsl-symlinks.sh.tmpl # WSL: WezTerm 設定を Windows へコピー（変更時に再実行）
-├── run_once_after_60-install-bat-themes.sh.tmpl    # bat: Catppuccin テーマ
 ├── run_onchange_after_50-fisher-sync.sh.tmpl       # fish_plugins 変更時に再実行
+├── run_once_after_60-install-bat-themes.sh.tmpl    # bat: Catppuccin テーマ
 └── .devcontainer/devcontainer.json
 ```
 


### PR DESCRIPTION
## Summary

- WSLのWezTerm設定同期の説明を「シンボリックリンク」→「コピー」に訂正（実装が `cp -f` であり、スクリプト内コメントにも「WSLからのシンボリックリンクはWindows側アプリに認識されない」と明記されているため）
- ディレクトリ構成の `run_once_after_60` と `run_onchange_after_50` の並び順を番号順に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)