### PR TITLE
fix: WSL向けHomebrew依存解決・sudo冒頭化・brew bundle進捗表示

### DIFF
--- a/run_once_before_10-install-homebrew.sh.tmpl
+++ b/run_once_before_10-install-homebrew.sh.tmpl
@@ -1,12 +1,27 @@
 #!/bin/bash
 # Homebrew のインストール（未インストールの場合のみ実行）
 # NONINTERACTIVE=1 を付けて DevContainer・CI 等の非対話環境でも止まらないように
+
+set -e
+
+{{ if not .is_mac -}}
+# Linux (WSL 含む): Homebrew が必要とする依存パッケージを先に入れる。
+# sudo が必要な処理をここでまとめて実行し、インストール途中でパスワードを
+# 聞かれないようにする。
+if ! command -v brew &>/dev/null && command -v apt-get &>/dev/null; then
+  echo "==> [Linux] Homebrew の依存パッケージをインストールします (sudo が必要です)..."
+  sudo -v  # ← ここでパスワードを一度入力。以降の sudo はキャッシュを利用
+  sudo apt-get update -q
+  sudo apt-get install -y build-essential curl file git
+fi
+{{ end -}}
+
 if ! command -v brew &>/dev/null; then
-  echo "Installing Homebrew..."
+  echo "==> Homebrew をインストールしています..."
   NONINTERACTIVE=1 /bin/bash -c \
     "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 else
-  echo "Homebrew already installed, skipping."
+  echo "Homebrew はインストール済みです。スキップします。"
 fi
 
 # インストール直後は brew が PATH に通っていないのでこのスクリプト内では明示的にロード

--- a/run_onchange_before_20-install-packages.sh.tmpl
+++ b/run_onchange_before_20-install-packages.sh.tmpl
@@ -24,7 +24,8 @@ BREWFILE="{{ .chezmoi.sourceDir }}/Brewfile"
 
 if [ -f "$BREWFILE" ]; then
   echo "Installing packages from Brewfile..."
-  brew bundle --file="$BREWFILE"
+  # --verbose: 各パッケージのダウンロード・インストール進捗を表示する
+  brew bundle --file="$BREWFILE" --verbose
 else
   echo "Brewfile not found, skipping."
 fi
@@ -33,6 +34,6 @@ fi
 BREWFILE_MAC="{{ .chezmoi.sourceDir }}/Brewfile.mac"
 if [ -f "$BREWFILE_MAC" ]; then
   echo "Installing Mac-only packages from Brewfile.mac..."
-  brew bundle --file="$BREWFILE_MAC"
+  brew bundle --file="$BREWFILE_MAC" --verbose
 fi
 {{- end }}


### PR DESCRIPTION
## 概要

WSLでのdotfilesセットアップ時に発生していた3つの問題を修正。

## 変更内容

### 1. `brew bundle` の進捗が表示されない
- **原因**: `brew bundle` はデフォルトで各パッケージの出力を抑制する
- **対応**: `--verbose` フラグを追加（Brewfile・Brewfile.mac 両方）
- marksman 等の大きなパッケージのダウンロード進捗が表示されるようになる

### 2. WSLでHomebrewが見つからない
- **原因**: フレッシュWSL(Ubuntu)では `build-essential` 等の依存パッケージが不足しており、Homebrewインストーラーが失敗する
- **対応**: Homebrewインストール前に `apt-get install build-essential curl file git` を実行

### 3. sudoパスワードが途中で求められる
- **原因**: Homebrewインストーラー内部で `sudo apt-get` が呼ばれる
- **対応**: スクリプト冒頭の `sudo -v` でパスワードを一度入力しキャッシュ。以降の sudo 呼び出しはキャッシュを利用

## 影響範囲
- macOSでは `{{ if not .is_mac }}` で囲まれているため無影響
- `apt-get` がない環境（非Debian系Linux）は `command -v apt-get` チェックでスキップ
- DevContainer・CI(GitHub Actions)では sudo がパスワードなしで通るため動作に変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)