### PR TITLE
docs: DevContainer の remoteEnv/UV_CACHE_DIR キャッシュ永続化テクニックを README に追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ jj config set --user user.email "you@example.com"
 }
 ```
 
+> **uv キャッシュを永続化したい場合**: `remoteEnv` で `UV_CACHE_DIR` をワークスペース内に向けると、コンテナを再ビルドしてもキャッシュが消えません（`/workspaces` は Docker ボリュームとしてマウントされるため）。
+>
+> ```json
+> {
+>   "name": "Ubuntu",
+>   "image": "mcr.microsoft.com/devcontainers/base:noble",
+>   "postCreateCommand": "bash .devcontainer/setup.sh",
+>   "remoteEnv": {
+>     "UV_CACHE_DIR": "/workspaces/<project-name>/.cache/uv"
+>   }
+> }
+> ```
+>
+> `remoteEnv` はコンテナ内のすべてのプロセスに環境変数を渡す設定です。`UV_CACHE_DIR` 以外にも `PIP_CACHE_DIR` や `NPM_CONFIG_CACHE` など、ツールのキャッシュをワークスペース内に集約するテクニックとして広く使えます。
+
 **`.devcontainer/setup.sh`**
 
 ```bash


### PR DESCRIPTION
## Summary

- `remoteEnv` で `UV_CACHE_DIR` をワークスペース内に向けることでコンテナ再ビルド後もキャッシュが維持される理由と使い方を Dev Container セクションに追記
- `PIP_CACHE_DIR` / `NPM_CONFIG_CACHE` など他ツールへの応用も補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)