### PR TITLE
fix: lazygit の日本語設定を追加

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -1,4 +1,5 @@
 gui:
+  language: "ja"
   theme:
     activeBorderColor:
       - green


### PR DESCRIPTION
ブランチ整理の過程で `gui.language: "ja"` の設定が main に入らなかったため追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)