### PR TITLE
feat: dotfiles 全体的な改善 (Brew追加・git config・WezTerm・chezmoi)

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,6 +1,7 @@
 {{- $is_wsl := false -}}
 {{- $is_mac := false -}}
 {{- $is_devcontainer := false -}}
+{{- $is_linux := false -}}
 
 {{- if env "WSL_DISTRO_NAME" -}}
   {{- $is_wsl = true -}}
@@ -12,6 +13,10 @@
   {{- $is_devcontainer = true -}}
 {{- end -}}
 
+{{- if and (eq .chezmoi.os "linux") (not $is_wsl) (not $is_devcontainer) -}}
+  {{- $is_linux = true -}}
+{{- end -}}
+
 # DevContainer / Codespaces ではクローン先が chezmoi のデフォルトと異なるため
 # sourceDir を明示的に記録しておく
 sourceDir = {{ .chezmoi.sourceDir | quote }}
@@ -20,3 +25,4 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
   is_wsl          = {{ $is_wsl }}
   is_mac          = {{ $is_mac }}
   is_devcontainer = {{ $is_devcontainer }}
+  is_linux        = {{ $is_linux }}

--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,9 @@
 brew "fish"
 brew "starship"
 
+# ── GitHub CLI ───────────────────────────────
+brew "gh"
+
 # ── Git / VCS ─────────────────────────────────
 brew "git"
 brew "git-delta"  # 高機能 diff viewer
@@ -32,5 +35,6 @@ brew "lazydocker"
 brew "ruff"
 brew "pyright"
 brew "shfmt"
+brew "shellcheck" # CI と同じ検証をローカルでも実行できるように
 brew "marksman"   # Markdown LSP
 brew "prettier"   # Markdown / JS / TS フォーマッタ

--- a/Brewfile.mac
+++ b/Brewfile.mac
@@ -3,9 +3,11 @@
 #       なので tap は不要です。
 
 # ── フォント ──────────────────────────────────
-# yuru7/HackGen は 2024年12月リリースで NerdFont 合成版のファミリー名を
-# `HackGenNerd*` から `HackGen*NF` に変更。wezterm.lua は両方フォールバック対応済み。
+# Moralerspace: v2.0.0 から NF グリフを本体に統合。font-moralerspace で OK（font-moralerspace-nf は廃止）
+# HackGen: yuru7/HackGen は 2024年12月リリースで NerdFont 合成版のファミリー名を
+#          `HackGenNerd*` から `HackGen*NF` に変更。wezterm.lua は両方フォールバック対応済み。
 cask "font-moralerspace"
+cask "font-hackgen-nerd"
 
 # ── GUIアプリ ─────────────────────────────────
 cask "wezterm"

--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -23,6 +23,3 @@ __pycache__/
 node_modules/
 .env
 .env.local
-
-# ── chezmoi ──────────────────────────────────
-.chezmoiscripts/

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -6,6 +6,5 @@ python = "3.12"
 node   = "lts"
 
 [settings]
-experimental    = true
 auto_install    = true   # tools 配列の変更で自動インストール
 plugin_autoupdate_last_check_duration = "1 week"

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -38,8 +38,10 @@ config.scrollback_lines = 10000
 -- ── ベル無効 ──────────────────────────────────
 config.audible_bell = "Disabled"
 
--- ── 互換性 ────────────────────────────────────
-config.term = "xterm-256color"
+-- ── ターミナル識別子 ──────────────────────────
+-- "wezterm" terminfo: Kitty keyboard protocol・true color など拡張機能を有効化
+-- SSH 先に wezterm terminfo がない場合は `TERM=xterm-256color ssh ...` で接続
+config.term = "wezterm"
 
 -- ── OS 別設定 ─────────────────────────────────
 {{ if .is_wsl -}}

--- a/run_onchange_after_55-setup-gitconfig.sh.tmpl
+++ b/run_onchange_after_55-setup-gitconfig.sh.tmpl
@@ -24,6 +24,10 @@ git config --global alias.co checkout
 
 git config --global pull.rebase false
 
+git config --global fetch.prune true
+git config --global rerere.enabled true
+git config --global push.autoSetupRemote true
+
 {{ if .is_wsl -}}
 git config --global credential.helper "/mnt/c/Program Files/Git/mingw64/bin/git-credential-manager.exe"
 {{- end }}

--- a/run_onchange_after_60-install-bat-themes.sh.tmpl
+++ b/run_onchange_after_60-install-bat-themes.sh.tmpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 # bat の Catppuccin テーマをインストール
+# catppuccin/bat version: v3.0.0  ← バージョンを変更すると chezmoi が再実行する
 set -e
 
 # brew が PATH にない場合はロード
@@ -25,10 +26,8 @@ mkdir -p "$THEME_DIR"
 BASE_URL="https://github.com/catppuccin/bat/raw/main/themes"
 for theme in "Catppuccin Mocha" "Catppuccin Macchiato" "Catppuccin Frappe" "Catppuccin Latte"; do
   filename="${theme}.tmTheme"
-  if [ ! -f "$THEME_DIR/$filename" ]; then
-    echo "Downloading $filename..."
-    curl -fsSL "${BASE_URL}/${filename// /%20}" -o "$THEME_DIR/$filename"
-  fi
+  echo "Downloading $filename..."
+  curl -fsSL "${BASE_URL}/${filename// /%20}" -o "$THEME_DIR/$filename"
 done
 
 # テーマキャッシュを再構築


### PR DESCRIPTION
## Summary

レビューで洗い出した改善点をまとめて適用。

### Brewfile / パッケージ
- `gh` (GitHub CLI) を追加 — CLAUDE.md のワークフローで多用しているのに未収録だった
- `shellcheck` を追加 — CI と同じ検証をローカルでも実行できるように
- `font-hackgen-nerd` を Brewfile.mac に追加 — WezTerm フォールバックに指定済みだが未収録だった
- Moralerspace NF 状況をコメントに記載 (v2.0.0 以降 NF グリフが本体に統合済みのため `font-moralerspace` で OK)

### git config
- `fetch.prune true` — fetch 時に削除済みリモートブランチを自動クリーン
- `rerere.enabled true` — 一度解決したコンフリクトを次回自動再解決
- `push.autoSetupRemote true` — 初回 push 時に -u origin が不要に (Git 2.37+)

### bat テーマスクリプト
- run_once_after_60 → run_onchange_after_60 にリネーム
- バージョンコメントを追加し、コメントを変えると chezmoi が再実行するように

### その他 cleanup
- .chezmoi.toml.tmpl: is_linux フラグを追加
- git/ignore: .chezmoiscripts/ はデッドエントリのため削除
- mise/config.toml: experimental = true を削除
- wezterm.lua.tmpl: term を xterm-256color → wezterm に変更

## Test plan

- [ ] CI がすべて通ること
- [ ] chezmoi apply 後に dotfiles-doctor でエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)