### PR TITLE
chore: remove unused gping and plugin-foreign-env

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,7 +20,6 @@ brew "fzf"
 brew "fd"        # fzf のファイル検索バックエンド
 brew "ripgrep"   # 高速 grep
 brew "dust"
-brew "gping"
 
 # ── Editor ────────────────────────────────────
 brew "helix"

--- a/dot_config/fish/fish_plugins
+++ b/dot_config/fish/fish_plugins
@@ -5,4 +5,3 @@ franciscolourenco/done
 decors/fish-colored-man
 gazorby/fish-abbreviation-tips
 meaningful-ooo/sponge
-oh-my-fish/plugin-foreign-env

--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -40,7 +40,6 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
         "CLI tools|fd|fd"                           \
         "CLI tools|ripgrep|rg"                      \
         "CLI tools|dust|dust"                       \
-        "CLI tools|gping|gping"                     \
         "Editor & LSP|helix|hx"                     \
         "Editor & LSP|ruff|ruff"                    \
         "Editor & LSP|pyright|pyright-langserver"   \


### PR DESCRIPTION
## Summary

未使用ツールの整理。

- `gping`: グラフ付き ping。他のツール・設定から参照されておらず実質未使用のため削除。あわせて `dotfiles-doctor` のチェックリストからも削除。
- `oh-my-fish/plugin-foreign-env`: bash スクリプトを fish で source する `fenv` コマンドを提供するが、fish 設定内でどこにも使用されていないため削除。mise が環境変数管理を担っている現在は不要。

## Test plan

- [ ] CI がすべて通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)