### PR TITLE
refactor: move uv to mise, remove just in favor of mise tasks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -32,9 +32,9 @@ brew "lazydocker"
 
 # ── データサイエンス / ML ──────────────────────
 brew "jq"        # JSON 処理（API レスポンス・設定ファイル操作）
-brew "uv"        # 高速 Python パッケージマネージャ（pip/venv 代替）
 brew "git-lfs"   # 大容量ファイル管理（モデル重みデータ・データセット）
-brew "just"      # タスクランナー（実験コマンドの Makefile 代替）
+# uv は mise で管理（dot_config/mise/config.toml 参照）
+# just は mise の内蔵タスクランナーで代替
 
 # ── 言語ツール（Helix LSP連携）───────────────
 brew "ruff"

--- a/dot_config/fish/conf.d/20_abbr.fish
+++ b/dot_config/fish/conf.d/20_abbr.fish
@@ -29,9 +29,6 @@ abbr -a cze  'chezmoi edit'
 abbr -a czu  'chezmoi update'
 abbr -a czcd 'chezmoi cd'
 
-# ── データサイエンス / ML ──────────────────────
-abbr -a j    'just'
-
 # ── ナビゲーション ────────────────────────────
 abbr -a ..    'cd ..'
 abbr -a ...   'cd ../..'

--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -50,8 +50,7 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
         "Docker|lazydocker|lazydocker"              \
         "データサイエンス / ML|jq|jq"               \
         "データサイエンス / ML|uv|uv"               \
-        "データサイエンス / ML|git-lfs|git-lfs"     \
-        "データサイエンス / ML|just|just"
+        "データサイエンス / ML|git-lfs|git-lfs"
 
     set -l ok 0
     set -l ng 0

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -4,6 +4,7 @@
 [tools]
 python = "3.12"
 node   = "lts"
+uv     = "latest"  # brew ではなく mise で管理（バージョン管理・一元化のため）
 
 [settings]
 auto_install    = true   # tools 配列の変更で自動インストール


### PR DESCRIPTION
## Summary

mise が汎用ツールマネージャーであることを踏まえ、brew との役割分担を整理。

### uv: brew → mise に移行

```toml
# dot_config/mise/config.toml
[tools]
uv = "latest"
```

mise は aqua 等のバックエンド経由で uv を管理できる。`mise activate` により PATH に自動で入るため、既存の dotfiles-doctor チェック (`command -q uv`) もそのまま動作する。

### just: 削除

mise に内蔵のタスクランナー (`mise run` / `mise tasks`) で代替可能。並列実行にも対応しており just より高機能。`j → just` の abbr も削除。

### 残す理由がある brew 管理ツール

- `jq`, `git-lfs`: バージョン固定が不要なシステム系ユーティリティ → brew で OK

## Test plan

- [ ] CI がすべて通ること
- [ ] `mise install` 後に `uv --version` が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)