### PR TITLE
feat: add git-sweep function and fix dotfiles-doctor gaps

### DIFF
--- a/dot_config/fish/functions/dotfiles-doctor.fish
+++ b/dot_config/fish/functions/dotfiles-doctor.fish
@@ -29,6 +29,7 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
         "Shell & Prompt|fisher|fisher"              \
         "dotfiles manager|chezmoi|chezmoi"          \
         "Git / VCS|git|git"                         \
+        "Git / VCS|gh|gh"                           \
         "Git / VCS|delta|delta"                     \
         "Git / VCS|lazygit|lazygit"                 \
         "Git / VCS|jj|jj"                           \
@@ -44,6 +45,7 @@ function dotfiles-doctor --description "Check dotfiles installation status (Mac 
         "Editor & LSP|ruff|ruff"                    \
         "Editor & LSP|pyright|pyright-langserver"   \
         "Editor & LSP|shfmt|shfmt"                  \
+        "Editor & LSP|shellcheck|shellcheck"        \
         "Editor & LSP|marksman|marksman"            \
         "Editor & LSP|prettier|prettier"            \
         "Version managers|mise|mise"                \

--- a/dot_config/fish/functions/git-sweep.fish
+++ b/dot_config/fish/functions/git-sweep.fish
@@ -1,0 +1,23 @@
+function git-sweep --description "Delete local branches whose remote tracking branch is gone (merged PRs)"
+    set -l gone (git branch -vv | grep ': gone]' | awk '{print $1}')
+
+    if test (count $gone) -eq 0
+        echo "No gone branches found."
+        return 0
+    end
+
+    echo "Gone branches:"
+    for b in $gone
+        echo "  $b"
+    end
+    echo ""
+
+    # -d（安全削除）で試みる。未マージ扱いのブランチは警告を出してスキップ
+    for b in $gone
+        if git branch -d $b 2>/dev/null
+            echo "✅ deleted $b"
+        else
+            echo "⚠️  $b: not fully merged locally — skipped (use 'git branch -D $b' to force)"
+        end
+    end
+end


### PR DESCRIPTION
## Summary

### git-sweep 関数を追加

`fetch.prune = true` の設定により、PR マージ後に remote tracking branch は自動削除されるが、ローカルブランチは手動削除が必要。`git-sweep` を呼ぶだけで gone ブランチをまとめて削除できるようにした。

```
$ git-sweep
Gone branches:
  feat/add-new-feature
  fix/some-bug

✅ deleted feat/add-new-feature
✅ deleted fix/some-bug
```

未マージ扱いのブランチは `-d` で削除を試み、失敗した場合は警告を出してスキップ（`git branch -D` での手動対応を促す）。

### dotfiles-doctor の抜け修正

PR #53 で Brewfile に追加したが doctor に反映されていなかった 2 ツールを追加。

- `gh` → Git / VCS セクション
- `shellcheck` → Editor & LSP セクション

## Test plan

- [ ] CI がすべて通ること
- [ ] `git-sweep` を fish で呼び出して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)